### PR TITLE
Allow passing an independent worker

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ function WorkerStream(path) {
   stream.Stream.call(me)
   this.readable = true
   this.writable = true
-  me.worker = new Worker(path)
+  me.worker = typeof path === 'string'
+    ? new Worker(path)
+    : path
   me.worker.onmessage = me.workerMessage.bind(this)
   me.worker.onerror = me.workerError.bind(this)
 }


### PR DESCRIPTION
This should make workerstream play nicer with modules such as webworkify, which are already creating and returning their own worker instances. Thanks! :)
