### PR TITLE
Emit data event data as a Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var stream = require('stream')
 var inherits = require('inherits');
+var toBuffer = require('typedarray-to-buffer');
+var isTypedArray = require('is-typedarray');
 
 function WorkerStream(path) {
   stream.Stream.call(this)
@@ -21,7 +23,9 @@ module.exports = function(path) {
 module.exports.WorkerStream = WorkerStream
 
 WorkerStream.prototype.workerMessage = function(e) {
-  this.emit('data', e.data, e)
+  var data = e.data;
+  if (isTypedArray(e.data) && !Buffer.isBuffer(data)) data = toBuffer(data);
+  this.emit('data', data, e)
 }
 
 WorkerStream.prototype.workerError = function(err) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "webworkify": "~0.1.0"
   },
   "dependencies": {
-    "inherits": "^2.0.1"
+    "inherits": "^2.0.1",
+    "is-typedarray": "0.0.0",
+    "typedarray-to-buffer": "^3.0.1"
   }
 }

--- a/parent.js
+++ b/parent.js
@@ -1,5 +1,7 @@
 var stream = require('stream')
 var inherits = require('inherits');
+var toBuffer = require('typedarray-to-buffer');
+var isTypedArray = require('is-typedarray');
 
 function ParentStream(workerGlobal){
   stream.Stream.call(this)
@@ -19,7 +21,9 @@ module.exports = function(workerGlobal) {
 module.exports.ParentStream = ParentStream
 
 ParentStream.prototype.parentMessage = function(e) {
-  this.emit('data', e.data, e)
+  var data = e.data;
+  if (isTypedArray(e.data) && !Buffer.isBuffer(data)) data = toBuffer(data);
+  this.emit('data', data, e)
 }
 
 ParentStream.prototype.parentError = function(err) {


### PR DESCRIPTION
For piping workerstreams to other streams (I'm using a websocket-stream) it is convenient for the `data` event payload to be of type `Buffer`, instead of `Uint8Array`. This PR checks whether the event data is a typed array, and if so converts it to a (browserify) [buffer](https://github.com/feross/buffer) using [typedarray-to-buffer](https://github.com/feross/typedarray-to-buffer). browserify-buffers are simply augmented Uint8Arrays, so typedarray-to-buffer is a zero-copy operation.

websocket-stream also performs a Buffer conversion, here: https://github.com/maxogden/websocket-stream/commit/0089ece2411d576910e7b5a42aaf27c82a1ff10e#diff-168726dbe96b3ce427e7fedce31bb0bcR58 (as of 1.0.0) - so I think it makes sense for workerstream to do so as well (with pre-1.0 versions of websocket-stream, I ran into the same problem being fixed here in workerstream)
